### PR TITLE
Add AWS cost debugging investigation scripts and checklist

### DIFF
--- a/scripts/aws-cost-debug/01-cost-explorer.sh
+++ b/scripts/aws-cost-debug/01-cost-explorer.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Cost Explorer – Amplify and WAF by Usage Type
+# Requires: AWS CLI, ce:GetCostAndUsage permission
+# Run: ./01-cost-explorer.sh [START_DATE] [END_DATE]
+# Example: ./01-cost-explorer.sh 2026-01-01 2026-01-31
+
+set -e
+
+START_DATE="${1:-$(date -v-30d +%Y-%m-%d 2>/dev/null || date -d '30 days ago' +%Y-%m-%d)}"
+END_DATE="${2:-$(date +%Y-%m-%d)}"
+
+echo "=== Cost Explorer: Amplify + WAF ==="
+echo "Period: $START_DATE to $END_DATE"
+echo ""
+
+echo "--- By Service (Amplify, WAF) ---"
+aws ce get-cost-and-usage \
+  --time-period Start="$START_DATE",End="$END_DATE" \
+  --granularity MONTHLY \
+  --metrics "UnblendedCost" \
+  --filter '{"Dimensions":{"Key":"SERVICE","Values":["AWS Amplify","AWS WAF"]}}' \
+  --group-by Type=DIMENSION,Key=SERVICE \
+  --output table 2>/dev/null || echo "Run: aws ce get-cost-and-usage --time-period Start=$START_DATE,End=$END_DATE --granularity MONTHLY --metrics UnblendedCost --filter '{\"Dimensions\":{\"Key\":\"SERVICE\",\"Values\":[\"AWS Amplify\",\"AWS WAF\"]}}' --group-by Type=DIMENSION,Key=SERVICE"
+
+echo ""
+echo "--- Amplify by Usage Type ---"
+aws ce get-cost-and-usage \
+  --time-period Start="$START_DATE",End="$END_DATE" \
+  --granularity MONTHLY \
+  --metrics "UnblendedCost" \
+  --filter '{"Dimensions":{"Key":"SERVICE","Values":["AWS Amplify"]}}' \
+  --group-by Type=DIMENSION,Key=USAGE_TYPE \
+  --output table 2>/dev/null || echo "See README for Console navigation"
+
+echo ""
+echo "--- WAF by Usage Type ---"
+aws ce get-cost-and-usage \
+  --time-period Start="$START_DATE",End="$END_DATE" \
+  --granularity MONTHLY \
+  --metrics "UnblendedCost" \
+  --filter '{"Dimensions":{"Key":"SERVICE","Values":["AWS WAF"]}}' \
+  --group-by Type=DIMENSION,Key=USAGE_TYPE \
+  --output table 2>/dev/null || echo "See README for Console navigation"
+
+echo ""
+echo "Data to collect: Amplify (Hosting-GB, Hosting-Requests, BuildMinutes, DataTransfer-Out); WAF (WebACL, Rule, Request)"

--- a/scripts/aws-cost-debug/02-waf-webacls.sh
+++ b/scripts/aws-cost-debug/02-waf-webacls.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# WAF – List Web ACLs, associations, and rules
+# Requires: AWS CLI, wafv2:ListWebACLs, wafv2:GetWebACL, wafv2:ListResourcesForWebACL
+# Note: WAF for CloudFront must use us-east-1
+
+set -e
+
+REGION="${1:-us-east-1}"
+SCOPE="CLOUDFRONT"  # Use REGIONAL for ALB/API Gateway
+
+echo "=== WAF Web ACLs (scope=$SCOPE, region=$REGION) ==="
+echo ""
+
+echo "--- Web ACL List ---"
+aws wafv2 list-web-acls --scope "$SCOPE" --region "$REGION" --output table 2>/dev/null || {
+  echo "If CloudFront: use us-east-1. If ALB: use your app region."
+  exit 1
+}
+
+echo ""
+echo "--- For each Web ACL, get details and associations ---"
+aws wafv2 list-web-acls --scope "$SCOPE" --region "$REGION" --query 'WebACLs[]' --output json 2>/dev/null | \
+  jq -r '.[] | "\(.ARN)|\(.Name)|\(.Id)"' 2>/dev/null | while IFS='|' read -r arn name id; do
+  [ -z "$arn" ] && continue
+  echo ""
+  echo "Web ACL: $name (Id: $id)"
+  echo "  ARN: $arn"
+  echo "  Rules:"
+  aws wafv2 get-web-acl --scope "$SCOPE" --id "$id" --name "$name" --region "$REGION" \
+    --query 'WebACL.Rules[*].{Name:Name,Priority:Priority}' --output table 2>/dev/null || true
+  echo "  Associated resources:"
+  aws wafv2 list-resources-for-web-acl --web-acl-arn "$arn" --resource-type CLOUDFRONT --region "$REGION" \
+    --query 'ResourceArns' --output table 2>/dev/null || echo "  (check Console)"
+done 2>/dev/null || {
+  echo "Run each Web ACL manually. Get Id from: aws wafv2 list-web-acls --scope CLOUDFRONT --region us-east-1"
+}
+
+echo ""
+echo "Screenshot: WAF & Shield -> Web ACLs -> [Your ACL] -> Rules tab (capacity units)"

--- a/scripts/aws-cost-debug/03-waf-metrics.sh
+++ b/scripts/aws-cost-debug/03-waf-metrics.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# WAF – CloudWatch Allowed/Blocked metrics
+# Requires: AWS CLI, cloudwatch:GetMetricStatistics, Web ACL Name and Id
+# Run: ./03-waf-metrics.sh [WEB_ACL_NAME] [WEB_ACL_ID]
+# Get name/id from: aws wafv2 list-web-acls --scope CLOUDFRONT --region us-east-1
+
+set -e
+
+WEB_ACL_NAME="${1}"
+WEB_ACL_ID="${2}"
+REGION="us-east-1"
+SCOPE="CLOUDFRONT"
+DAYS="${3:-14}"
+
+if [ -z "$WEB_ACL_NAME" ] || [ -z "$WEB_ACL_ID" ]; then
+  echo "Usage: $0 WEB_ACL_NAME WEB_ACL_ID [DAYS]"
+  echo ""
+  echo "Get Web ACL name and ID:"
+  aws wafv2 list-web-acls --scope CLOUDFRONT --region us-east-1 --output table 2>/dev/null || true
+  exit 1
+fi
+
+END=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+START=$(date -u -v-${DAYS}d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "$DAYS days ago" +%Y-%m-%dT%H:%M:%SZ)
+
+echo "=== WAF CloudWatch Metrics: $WEB_ACL_NAME ==="
+echo "Period: last $DAYS days"
+echo ""
+
+echo "--- Allowed Requests ---"
+aws cloudwatch get-metric-statistics \
+  --namespace AWS/WAFV2 \
+  --metric-name AllowedRequests \
+  --dimensions Name=WebACL,Value="$WEB_ACL_NAME/$WEB_ACL_ID" Name=Region,Value=us-east-1 Name=Rule,Value=ALL \
+  --start-time "$START" \
+  --end-time "$END" \
+  --period 86400 \
+  --statistics Sum \
+  --region "$REGION" \
+  --output table 2>/dev/null || echo "Check Web ACL name/id. For CloudFront WAF, Region=us-east-1."
+
+echo ""
+echo "--- Blocked Requests ---"
+aws cloudwatch get-metric-statistics \
+  --namespace AWS/WAFV2 \
+  --metric-name BlockedRequests \
+  --dimensions Name=WebACL,Value="$WEB_ACL_NAME/$WEB_ACL_ID" Name=Region,Value=us-east-1 Name=Rule,Value=ALL \
+  --start-time "$START" \
+  --end-time "$END" \
+  --period 86400 \
+  --statistics Sum \
+  --region "$REGION" \
+  --output table 2>/dev/null || true
+
+echo ""
+echo "Look for: Blocked >> Allowed = bot/scanner traffic. Check Sampled Requests in Console for top rules."

--- a/scripts/aws-cost-debug/04-budget-anomaly.sh
+++ b/scripts/aws-cost-debug/04-budget-anomaly.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Create AWS Budget with Anomaly Detection
+# Requires: AWS CLI, budgets:CreateBudget, budgets:CreateAnomalyMonitor, budgets:CreateAnomalySubscription
+# Run: ./04-budget-anomaly.sh [MONTHLY_BUDGET_USD] [EMAIL]
+
+set -e
+
+BUDGET_AMOUNT="${1:-50}"
+EMAIL="${2}"
+
+if [ -z "$EMAIL" ]; then
+  echo "Usage: $0 MONTHLY_BUDGET_USD EMAIL"
+  echo "Example: $0 50 you@example.com"
+  exit 1
+fi
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text 2>/dev/null || echo "YOUR_ACCOUNT_ID")
+
+echo "=== Creating Budget: \$$BUDGET_AMOUNT/month ==="
+echo "Notifications to: $EMAIL"
+echo ""
+
+# Create budget with forecasted and actual alerts
+aws budgets create-budget \
+  --account-id "$ACCOUNT_ID" \
+  --budget "{
+    \"BudgetName\": \"panetteria-monthly\",
+    \"BudgetLimit\": {
+      \"Amount\": \"$BUDGET_AMOUNT\",
+      \"Unit\": \"USD\"
+    },
+    \"TimeUnit\": \"MONTHLY\",
+    \"BudgetType\": \"COST\",
+    \"CostFilters\": {},
+    \"CostTypes\": {
+      \"IncludeTax\": true,
+      \"IncludeSubscription\": true,
+      \"UseBlended\": false,
+      \"IncludeRefund\": false,
+      \"IncludeCredit\": false,
+      \"IncludeUpfront\": true,
+      \"IncludeRecurring\": true,
+      \"IncludeOtherSubscription\": true,
+      \"IncludeSupport\": true,
+      \"IncludeDiscount\": true,
+      \"UseAmortized\": false
+    }
+  }" \
+  --notifications-with-subscribers "[
+    {
+      \"Notification\": {
+        \"NotificationType\": \"FORECASTED\",
+        \"ComparisonOperator\": \"GREATER_THAN\",
+        \"Threshold\": 80,
+        \"ThresholdType\": \"PERCENTAGE\"
+      },
+      \"Subscribers\": [{\"SubscriptionType\": \"EMAIL\", \"Address\": \"$EMAIL\"}]
+    },
+    {
+      \"Notification\": {
+        \"NotificationType\": \"ACTUAL\",
+        \"ComparisonOperator\": \"GREATER_THAN\",
+        \"Threshold\": 100,
+        \"ThresholdType\": \"PERCENTAGE\"
+      },
+      \"Subscribers\": [{\"SubscriptionType\": \"EMAIL\", \"Address\": \"$EMAIL\"}]
+    }
+  ]" 2>/dev/null || {
+  echo "Budget may already exist. Use Console: Billing -> Budgets -> Create budget"
+  exit 1
+}
+
+echo "Budget created. Enabling Anomaly Detection..."
+
+# Anomaly monitor (tracks spend patterns)
+aws budgets create-anomaly-monitor \
+  --anomaly-monitor "{
+    \"AnomalyMonitorName\": \"panetteria-anomaly\",
+    \"MonitorType\": \"DIMENSIONAL\",
+    \"MonitorDimension\": \"SERVICE\"
+  }" 2>/dev/null || echo "Anomaly monitor may exist. Check Billing -> Cost Anomaly Detection."
+
+# Anomaly subscription
+MONITOR_ARN=$(aws budgets describe-anomaly-monitors --query "AnomalyMonitors[?AnomalyMonitor.AnomalyMonitorName=='panetteria-anomaly'].AnomalyMonitor.MonitorArn" --output text 2>/dev/null | head -1)
+if [ -n "$MONITOR_ARN" ] && [ "$MONITOR_ARN" != "None" ]; then
+  aws budgets create-anomaly-subscription \
+    --anomaly-subscription "{
+      \"AnomalySubscriptionName\": \"panetteria-anomaly-alerts\",
+      \"MonitorArnList\": [\"$MONITOR_ARN\"],
+      \"Subscribers\": [{\"SubscriptionType\": \"EMAIL\", \"Address\": \"$EMAIL\"}],
+      \"Threshold\": 50.0,
+      \"Frequency\": \"IMMEDIATE\"
+    }" 2>/dev/null || echo "Subscription may exist."
+fi
+
+echo ""
+echo "Done. Check Billing -> Budgets and Cost Anomaly Detection. Confirm email subscription."

--- a/scripts/aws-cost-debug/README.md
+++ b/scripts/aws-cost-debug/README.md
@@ -1,0 +1,138 @@
+# AWS Cost Debugging Investigation
+
+Scripts and checklist for investigating Amplify + WAF cost drivers and implementing mitigations.
+
+## Prerequisites
+
+- AWS CLI configured with `aws configure`
+- Permissions: `ce:*`, `wafv2:*`, `cloudwatch:GetMetricStatistics`, `budgets:*` (or use Console)
+
+## Quick Start
+
+```bash
+# 1. Cost Explorer (Amplify + WAF by usage type)
+./01-cost-explorer.sh 2026-01-01 2026-01-31
+
+# 2. List WAF Web ACLs and rules
+./02-waf-webacls.sh us-east-1
+
+# 3. WAF metrics (replace with your Web ACL name/id from step 2)
+./03-waf-metrics.sh YourWebACLName abc123def 14
+
+# 4. Budget + Anomaly Detection
+./04-budget-anomaly.sh 50 your@email.com
+```
+
+---
+
+## AWS Console Navigation (Exact Steps)
+
+### 1.1 Cost Explorer – Service + Usage Type
+
+1. AWS Console → **Billing** → **Cost Explorer**
+2. **Create report** or use existing
+3. **Time range:** Last 30 days (or custom: Jan 2026)
+4. **Group by:** Service → Filter: `AWS Amplify`, `AWS WAF`
+5. **Create second view:** Group by → **Usage Type** (and Region if needed)
+
+**Screenshot:** Amplify line items (Hosting-GB, Hosting-Requests, BuildMinutes, DataTransfer-Out); WAF (WebACL, Rule, Request)
+
+---
+
+### 1.2 WAF – Web ACLs and Associations
+
+1. AWS Console → **WAF & Shield** → **Web ACLs**
+2. For each Web ACL: **Associated AWS resources** tab
+3. Note CloudFront distribution ID(s) or ALB ARN(s)
+
+**Screenshot:** Web ACL names, associated resources
+
+---
+
+### 1.3 WAF – Managed Rule Groups and Rules
+
+1. WAF & Shield → **Web ACLs** → [Your Web ACL] → **Rules**
+2. List all rules (managed + custom)
+3. Note capacity units per managed rule group
+
+**Screenshot:** Full rule list with capacity units
+
+---
+
+### 1.4 Amplify – App Billing
+
+1. AWS Console → **Amplify** → [Your App] → **App settings** → **Billing**
+2. Or: **Hosting** → Build history
+
+**Screenshot:** Build minutes, hosting requests, build count (last 60 days)
+
+---
+
+### 2.1 WAF – CloudWatch Metrics
+
+1. WAF & Shield → **Web ACLs** → [Your Web ACL] → **Monitoring**
+2. View **Allowed requests** and **Blocked requests** (last 14 days)
+3. **Sampled requests** (if enabled) for top rules
+
+**Screenshot:** Allowed vs Blocked over time, spike dates
+
+---
+
+### 2.2 CloudFront Access Logs (Optional)
+
+1. **CloudFront** → **Distributions** → [Amplify’s distribution] → **General**
+2. **Standard logging** → Enable, set S3 bucket
+3. Wait 24–48h, analyze: top URIs, IPs, user agents
+
+---
+
+### 2.3 Amplify – Build History
+
+1. Amplify → [Your App] → **Hosting** → **Build history**
+2. Filter last 60 days, count builds, note triggers
+
+---
+
+## Decision Tree
+
+| If | Then |
+|----|------|
+| WAF Request count high? | → Blocked >> Allowed? → **Yes:** Bot traffic → Remove WAF or simplify rules |
+| | → **No:** Legitimate high → Caching, rate limits |
+| | → Request count low? → Rule/capacity cost → Fewer rule groups |
+| Build minutes high? | → Reduce branches, disable auto-builds |
+| Hosting requests high? | → Enable caching, check bots |
+| Data transfer high? | → Optimize images, enable caching |
+
+---
+
+## Cost-Saving Options
+
+| Action | Savings | Risk |
+|--------|---------|------|
+| **Remove WAF** | ~$10/mo | No bot/DDoS protection; OK for static marketing site |
+| **Simplify WAF rules** | 20–50% | Slightly less protection |
+| **Add rate-based rule** | Variable | May block burst traffic |
+| **Block scanner paths** | Variable | Maintain allowlist |
+| **Enable CloudFront caching** | Lower origin | Set cache headers (index.html no-cache, assets long) |
+| **Disable unused branches** | Build minutes | None |
+| **Budget + Anomaly Detection** | Alerting | None |
+
+---
+
+## Prioritized Checklist
+
+1. [ ] Cost Explorer – Amplify and WAF by Usage Type (5 min)
+2. [ ] WAF – List Web ACLs, rules, capacity (5 min)
+3. [ ] WAF – CloudWatch Allowed/Blocked metrics (5 min)
+4. [ ] Amplify – Build history and billing (5 min)
+5. [ ] Apply decision tree with Phase 1 data
+6. [ ] If WAF requests high – Enable logs, analyze
+7. [ ] Implement mitigations – Budget first, then WAF removal if appropriate
+
+---
+
+## Disassociate WAF (If Removing)
+
+1. WAF & Shield → **Web ACLs** → [Your ACL] → **Associated AWS resources**
+2. Select CloudFront distribution → **Disassociate**


### PR DESCRIPTION
Implements the AWS Cost Debugging Investigation Plan with executable scripts and documentation.

## What's included

- **01-cost-explorer.sh** – Cost Explorer for Amplify + WAF by usage type
- **02-waf-webacls.sh** – List WAF Web ACLs, rules, associations
- **03-waf-metrics.sh** – CloudWatch Allowed/Blocked metrics
- **04-budget-anomaly.sh** – Budget + Anomaly Detection setup
- **README.md** – Console navigation, decision tree, checklist

## Usage

```bash
cd scripts/aws-cost-debug
./01-cost-explorer.sh 2026-01-01 2026-01-31
./02-waf-webacls.sh us-east-1
./03-waf-metrics.sh WebACLName WebACLId 14
./04-budget-anomaly.sh 50 your@email.com
```

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds standalone investigation/ops scripts and documentation only; no production application code paths are modified. Main risk is accidental execution in the wrong AWS account/region or creating budget/anomaly resources unintentionally.
> 
> **Overview**
> Introduces a new `scripts/aws-cost-debug` folder with runnable AWS CLI scripts to (1) query Cost Explorer spend for `AWS Amplify` and `AWS WAF` grouped by service/usage type, (2) enumerate WAFv2 Web ACLs, rules, and associated resources, (3) fetch CloudWatch `AllowedRequests`/`BlockedRequests` metrics for a given Web ACL, and (4) create a monthly AWS Budget plus cost anomaly monitor/subscription.
> 
> Adds a `README.md` checklist with exact Console navigation steps, a decision tree for diagnosing drivers (requests vs rule capacity vs builds/hosting/transfer), and suggested mitigations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5081103bcbcfb6f4cf29e450b15b2a4d03ec4a13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->